### PR TITLE
enabled KC3 backup file access, added copy/save image functions

### DIFF
--- a/packages/electron-chrome-context-menu/index.ts
+++ b/packages/electron-chrome-context-menu/index.ts
@@ -99,7 +99,7 @@ export const buildChromeContextMenu = (opts: ChromeContextMenuOptions): Menu => 
       },
     })
     appendSeparator()
-  } else if (params.mediaType !== 'none' && params.mediaType !== 'canvas') {
+  } else if (params.mediaType !== 'none' && params.mediaType !== 'canvas' && params.mediaType !== 'image') {
     // TODO: Loop, Show controls
     append({
       label: labels.openInNewTab(params.mediaType),
@@ -114,9 +114,36 @@ export const buildChromeContextMenu = (opts: ChromeContextMenuOptions): Menu => 
       },
     })
     appendSeparator()
+  } else if (params.mediaType === 'image') {
+    append({
+      label: labels.openInNewTab(params.mediaType),
+      click: () => {
+        openLink(params.srcURL, 'default', params)
+      },
+    })
+    append({
+      label: labels.copyAddress(params.mediaType),
+      click: () => {
+        clipboard.writeText(params.srcURL)
+      },
+    })
+    appendSeparator()
+    append({
+      label: 'Copy image',
+      click: () => {
+        webContents.copyImageAt(params.x, params.y)
+      }}
+    )
+    append({
+      label: 'Save image',
+      click: () => {
+        webContents.downloadURL(params.srcURL)
+      }}
+    )
+    appendSeparator()
   } else if (params.mediaType === 'canvas') {
     append({
-      label: 'Copy Image',
+      label: 'Copy image',
       click: () => {
         const copy = `function takeScreenshot() {
     let canvas = document.querySelector('#unity-canvas') // Unity canvas
@@ -136,7 +163,7 @@ takeScreenshot()`
       },
     })
     append({
-      label: 'Save Image',
+      label: 'Save image',
       click: () => {
         const save = `function saveImage() {
     let canvas = document.querySelector('#unity-canvas') // Unity canvas

--- a/packages/shell/browser/main.js
+++ b/packages/shell/browser/main.js
@@ -54,7 +54,7 @@ app.commandLine.appendSwitch("force-gpu-mem-available-mb", "10000")
 app.commandLine.appendSwitch("force-gpu-rasterization")
 app.commandLine.appendSwitch("enable-native-gpu-memory-buffers")
 app.commandLine.appendSwitch("enable-gpu-memory-buffer-compositor-resources")
-
+app.commandLine.appendSwitch("enable-experimental-web-platform-features");
 
 if (process.execPath.match(/(damecon(-browser)?|chrome)/)) {
   currPath = path.dirname(process.execPath)


### PR DESCRIPTION
<!-- Please include a description of changes. -->
Small changes:
- Enabled _enable-experimental-web-platform-features_ command flag, which allows KC3 write filesystem access. By default, Electron's filesystem write permissions are always false (not implemented as of now), so this most likely makes the browser less secure as well.
- Added functions to copy and save common images
---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
