### PR TITLE
Added CSS to remove themed window-controls and pad tabstrip on MacOS

### DIFF
--- a/packages/shell/browser/ui/webui.css
+++ b/packages/shell/browser/ui/webui.css
@@ -238,8 +238,8 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'Ubuntu', 'Droid Sans',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'Ubuntu', 'Droid Sans', sans-serif;
   font-size: 16px;
 }
 
@@ -652,4 +652,12 @@ browser-action-list::part(action):hover {
   background: conic-gradient(white 0% calc(var(--pct) * 1%), #ffffff1f calc(var(--pct) * 1%) 100%);
   width: 100%;
   height: 100%;
+}
+
+.platform-macos #tabstrip {
+  padding-left: 70px;
+}
+
+.platform-macos .window-controls {
+  display: none;
 }


### PR DESCRIPTION
Added a couple lines to webui.css that hides the themed minimize/maximize/close window buttons and shifts to the tabs over so that the MacOS window control buttons aren't overlapping with them.  
---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
