### PR TITLE
Some CSS Tweaks

### DIFF
--- a/packages/shell/browser/ui/new-tab.css
+++ b/packages/shell/browser/ui/new-tab.css
@@ -10,6 +10,7 @@
   align-items: center;
   align-content: center;
   justify-content: center;
+  width: 100%;
 }
 
 .header {

--- a/packages/shell/browser/ui/new-tab.css
+++ b/packages/shell/browser/ui/new-tab.css
@@ -10,7 +10,6 @@
   align-items: center;
   align-content: center;
   justify-content: center;
-  width: 100%;
 }
 
 .header {

--- a/packages/shell/browser/ui/new-tab.css
+++ b/packages/shell/browser/ui/new-tab.css
@@ -39,7 +39,7 @@
 .links {
   display: flex;
   flex-direction: row;
-  width: 800px;
+  width: 100%;
 }
 
 .col {

--- a/packages/shell/browser/ui/webui.css
+++ b/packages/shell/browser/ui/webui.css
@@ -654,10 +654,14 @@ browser-action-list::part(action):hover {
   height: 100%;
 }
 
+/*MacOS Modifications*/
+
 .platform-macos #tabstrip {
   padding-left: 70px;
 }
 
-.platform-macos .window-controls {
+.platform-macos .window-controls .control#minimize,
+.control#maximize,
+.control#close {
   display: none;
 }


### PR DESCRIPTION
Changed new tab css so the links section would resize with the window width.
Modified the MacOS window control CSS section so that it would only remove specific controls and not all of them. 
---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
